### PR TITLE
[FIX] Exit Code in errorExit function

### DIFF
--- a/sinusbot_installer.sh
+++ b/sinusbot_installer.sh
@@ -38,7 +38,7 @@ function errorQuit {
 
 function errorExit {
   redMessage "${@}"
-  exit 0
+  exit 1
 }
 
 function errorContinue {


### PR DESCRIPTION
0 means that the script ran successful or ok and 1 means that a error has occurred. The function errorExit is always used to display an error and exit so the exit code 1 should be the right one.