### PR TITLE
feat: make apt upgrade optional (fix: #71)

### DIFF
--- a/sinusbot_installer.sh
+++ b/sinusbot_installer.sh
@@ -574,13 +574,12 @@ fi
 
 # Update packages or not
 
-redMessage 'Update the system packages to the latest version? Recommended, as otherwise dependencies might break! Option "No" will exit the installer'
+redMessage 'Update the system packages to the latest version? (Recommended)'
 
 OPTIONS=("Yes" "No")
 select OPTION in "${OPTIONS[@]}"; do
   case "$REPLY" in
-  1) break ;;
-  2) errorQuit ;;
+  1 | 2) break ;;
   *) errorContinue ;;
   esac
 done

--- a/startup.go
+++ b/startup.go
@@ -55,7 +55,7 @@ func main() {
 				Detect: "Check your time below:",
 			},
 			parameter{
-				Value:  "1",
+				Value:  "2",
 				Detect: "Update the system packages to the latest version?",
 			},
 			parameter{


### PR DESCRIPTION
Integrates the optional upgrade process discussed in #71.